### PR TITLE
feat(rssify): add FILENAME to env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,7 @@ runs:
        echo "ITEM_DATE_CSS=${{ inputs.item-date-css }}" >> $GITHUB_ENV
        echo "ITEM_DATE_FORMAT=${{ inputs.item-date-format }}" >> $GITHUB_ENV
        echo "ITEM_TIMEZONE=${{ inputs.item-timezone }}" >> $GITHUB_ENV
+       echo "FILENAME=${{ inputs.filename }}" >> $GITHUB_ENV
       shell: bash
     - name: Generate RSS files
       run: python ${{ github.action_path }}/rssify.py

--- a/rssify.py
+++ b/rssify.py
@@ -19,6 +19,7 @@ item_description_selector = os.environ.get('ITEM_DESCRIPTION_CSS')
 item_date_selector = os.environ.get('ITEM_DATE_CSS')
 item_date_format = os.environ.get('ITEM_DATE_FORMAT')
 item_timezone = os.environ.get('ITEM_TIMEZONE')
+filename = os.environ.get('FILENAME', 'atom.xml')
 
 r = requests.get(url)
 soup = BeautifulSoup(r.text, 'lxml')
@@ -74,4 +75,4 @@ for i in range(len(titles)):
     fe.published(date)
     fe.updated(date)
 
-fg.atom_file('atom.xml')
+fg.atom_file(filename)


### PR DESCRIPTION
Background
- I want to generate RSS feeds from multiple pipelines at the same time. 
- So I receive the file name as a parameter.

Changes
- action.yml: allows input.filename
- rssify.py: receive FILENAME env variable.  the default value is atom.xml